### PR TITLE
Add starting pose and simulated field support

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -71,7 +71,6 @@
       "/LiveWindow/Ungrouped/Scheduler": "Scheduler",
       "/Shuffleboard/BabySwerve/Auto Modes": "String Chooser",
       "/Shuffleboard/ExampleRobot/Auto Modes": "String Chooser",
-      "/Shuffleboard/Pose/Pose Field": "Field2d",
       "/SmartDashboard/Alerts": "Alerts",
       "/SmartDashboard/Arm/mechanism": "Mechanism2d",
       "/SmartDashboard/Auto Modes": "String Chooser",
@@ -164,7 +163,7 @@
           "width": 0.44999998807907104
         },
         "CARPET18": {
-          "image": "C:\\workspace\\FRC5010LibExample\\Example\\pictures\\carpet.png",
+          "image": ".\\pictures\\carpet.png",
           "length": 0.4000000059604645,
           "width": 0.4000000059604645
         },
@@ -668,17 +667,9 @@
         "left": 534,
         "right": 3466,
         "top": 291,
-        "width": 17.54825210571289,
-        "window": {
-          "visible": true
-        }
+        "width": 17.54825210571289
       },
       "/SmartDashboard/Robot Visual": {
-        "window": {
-          "visible": true
-        }
-      },
-      "/SmartDashboard/Turret/mechanism": {
         "window": {
           "visible": true
         }

--- a/src/main/deploy/basic_robot/cameras.json
+++ b/src/main/deploy/basic_robot/cameras.json
@@ -5,5 +5,6 @@
     "shooter.json",
     "quest.json"
   ],
-  "aprilTagLayout": "/org/frc5010/lobbinloco/LobbinLoco.json"
+  "aprilTagLayout": "/org/frc5010/lobbinloco/LobbinLoco.json",
+  "simulatedField": "org.frc5010.lobbinloco.LobbinLoco"
 }

--- a/src/main/deploy/basic_robot/yagsl_drivetrain.json
+++ b/src/main/deploy/basic_robot/yagsl_drivetrain.json
@@ -6,5 +6,19 @@
     "frontright.json",
     "backleft.json",
     "backright.json"
-  ]
+  ],
+  "startingPose": {
+    "x": {
+      "val": 1.0,
+      "uom": "m"
+    },
+    "y": {
+      "val": 1.0,
+      "uom": "m"
+    },
+    "rotation": {
+      "val": 0.0,
+      "uom": "deg"
+    }
+  }
 }

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,13 +5,13 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "FRC5010Example";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = -1;
-  public static final String GIT_SHA = "UNKNOWN";
-  public static final String GIT_DATE = "UNKNOWN";
-  public static final String GIT_BRANCH = "UNKNOWN";
-  public static final String BUILD_DATE = "2025-09-24 17:41:21 EDT";
-  public static final long BUILD_UNIX_TIME = 1758750081528L;
-  public static final int DIRTY = 0;
+  public static final int GIT_REVISION = 1;
+  public static final String GIT_SHA = "a5a7602d311560232663a0b03e3e2a5939ad101a";
+  public static final String GIT_DATE = "2025-09-24 17:41:55 EDT";
+  public static final String GIT_BRANCH = "main";
+  public static final String BUILD_DATE = "2025-09-25 20:26:00 EDT";
+  public static final long BUILD_UNIX_TIME = 1758846360959L;
+  public static final int DIRTY = 1;
 
   private BuildConstants() {}
 }

--- a/src/main/java/org/frc5010/common/config/json/Pose2dJson.java
+++ b/src/main/java/org/frc5010/common/config/json/Pose2dJson.java
@@ -1,0 +1,12 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.frc5010.common.config.json;
+
+/** A Unit aware 2D pose JSON object */
+public class Pose2dJson {
+  public UnitValueJson x = new UnitValueJson(0, "m");
+  public UnitValueJson y = new UnitValueJson(0, "m");
+  public UnitValueJson rotation = new UnitValueJson(0, "deg");
+}

--- a/src/main/java/org/frc5010/common/config/json/VisionPropertiesJson.java
+++ b/src/main/java/org/frc5010/common/config/json/VisionPropertiesJson.java
@@ -9,10 +9,12 @@ import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import org.frc5010.common.arch.GenericRobot;
 import org.frc5010.common.vision.AprilTags;
+import org.ironmaple.simulation.SimulatedArena;
 
 /** JSON class with an array of cameras to configure */
 public class VisionPropertiesJson {
@@ -20,6 +22,7 @@ public class VisionPropertiesJson {
   public String[] cameras;
 
   public String aprilTagLayout = "default";
+  public String simulatedField = "default";
 
   /**
    * Creates cameras for a given robot using the provided map of camera configurations.
@@ -43,6 +46,23 @@ public class VisionPropertiesJson {
    * @return the map of camera configurations
    */
   public Map<String, CameraConfigurationJson> readCameraSystem(File directory) throws IOException {
+    if (!simulatedField.equalsIgnoreCase("default")) {
+      try {
+        SimulatedArena arena =
+            Class.forName(simulatedField)
+                .asSubclass(SimulatedArena.class)
+                .getDeclaredConstructor()
+                .newInstance();
+        SimulatedArena.overrideInstance(arena);
+      } catch (ClassNotFoundException
+          | NoSuchMethodException
+          | InstantiationException
+          | IllegalAccessException
+          | InvocationTargetException e) {
+        System.err.println("Error creating arena instance: " + e.getMessage());
+        throw new RuntimeException(e);
+      }
+    }
     if (aprilTagLayout.equals("5010")) {
       AprilTags.setAprilTagFieldLayout(AprilTags.aprilTagRoomLayout);
     } else if (aprilTagLayout.equals("default")) {

--- a/src/main/java/org/frc5010/common/config/json/YAGSLDrivetrainJson.java
+++ b/src/main/java/org/frc5010/common/config/json/YAGSLDrivetrainJson.java
@@ -4,13 +4,19 @@
 
 package org.frc5010.common.config.json;
 
+import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Meters;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.RobotBase;
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 import org.frc5010.common.arch.GenericRobot;
 import org.frc5010.common.config.ConfigConstants;
+import org.frc5010.common.config.UnitsParser;
 import org.frc5010.common.constants.MotorFeedFwdConstants;
 import org.frc5010.common.constants.RobotConstantsDef;
 import org.frc5010.common.constants.SwerveConstants;
@@ -32,6 +38,9 @@ public class YAGSLDrivetrainJson implements DrivetrainPropertiesJson {
    * in the YAGSL config
    */
   public String[] driveModules;
+
+  /** Starting pose of the robot */
+  public Pose2dJson startingPose = new Pose2dJson();
 
   public void readDrivetrainConfiguration(GenericRobot robot, File baseDirectory)
       throws IOException {
@@ -59,14 +68,19 @@ public class YAGSLDrivetrainJson implements DrivetrainPropertiesJson {
         }
       }
     }
-    return;
   }
   ;
 
   @Override
   public void createDriveTrain(GenericRobot robot) {
+    Pose2d startingPoseFromJson =
+        new Pose2d(
+            UnitsParser.parseDistance(startingPose.x).in(Meters),
+            UnitsParser.parseDistance(startingPose.y).in(Meters),
+            new Rotation2d(UnitsParser.parseAngle(startingPose.rotation).in(Degrees)));
     YAGSLSwerveDrivetrain yagsl =
-        new YAGSLSwerveDrivetrain(robot.getDrivetrainConstants(), turningMotorGearRatio, directory);
+        new YAGSLSwerveDrivetrain(
+            robot.getDrivetrainConstants(), turningMotorGearRatio, directory, startingPoseFromJson);
     GenericSwerveDrivetrain drivetrain =
         new GenericSwerveDrivetrain(
             new LoggedMechanism2d(RobotConstantsDef.robotVisualH, RobotConstantsDef.robotVisualV),

--- a/src/main/java/org/frc5010/common/drive/swerve/YAGSLSwerveDrivetrain.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/YAGSLSwerveDrivetrain.java
@@ -5,7 +5,6 @@
 package org.frc5010.common.drive.swerve;
 
 import static edu.wpi.first.units.Units.DegreesPerSecond;
-import static edu.wpi.first.units.Units.Meter;
 import static edu.wpi.first.units.Units.Second;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -61,7 +60,10 @@ public class YAGSLSwerveDrivetrain extends SwerveDriveFunctions {
   public double maximumSpeed = Units.feetToMeters(19.5);
 
   public YAGSLSwerveDrivetrain(
-      GenericDrivetrainConstants constants, double kTurningMotorGearRatio, String swerveType) {
+      GenericDrivetrainConstants constants,
+      double kTurningMotorGearRatio,
+      String swerveType,
+      Pose2d initialPose) {
     this.maximumSpeed = constants.getkTeleDriveMaxSpeedMetersPerSecond();
 
     // Angle conversion factor is 360 / (GEAR RATIO * ENCODER RESOLUTION)
@@ -94,12 +96,7 @@ public class YAGSLSwerveDrivetrain extends SwerveDriveFunctions {
     try {
       File swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), swerveType);
       swerveDrive =
-          new SwerveParser(swerveJsonDirectory)
-              .createSwerveDrive(
-                  maximumSpeed,
-                  new Pose2d(
-                      new Translation2d(Meter.of(7.417), Meter.of(4)),
-                      Rotation2d.fromDegrees(180)));
+          new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed, initialPose);
     } catch (Exception e) {
       System.out.println(e.getMessage());
       throw new RuntimeException(e);

--- a/src/main/java/org/frc5010/lobbinloco/LobbinLoco.java
+++ b/src/main/java/org/frc5010/lobbinloco/LobbinLoco.java
@@ -1,0 +1,46 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.frc5010.lobbinloco;
+
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.units.Units;
+import org.ironmaple.simulation.SimulatedArena;
+
+/** Add your docs here. */
+public class LobbinLoco extends SimulatedArena {
+  // Dimensions in meters (50 feet x 20 feet)
+  private static final Translation2d bottomLeft = new Translation2d(0.0, 0.0);
+  private static final Translation2d bottomRight =
+      new Translation2d(Units.Feet.of(15).in(Units.Meters), 0);
+  private static final Translation2d topLeft =
+      new Translation2d(0.0, Units.Feet.of(20).in(Units.Meters));
+  private static final Translation2d topRight =
+      new Translation2d(Units.Feet.of(16).in(Units.Meters), Units.Feet.of(20).in(Units.Meters));
+
+  private static class LobbinLoboFieldMap extends FieldMap {
+    public LobbinLoboFieldMap() {
+      this.addBorderLine(bottomLeft, bottomRight);
+      this.addBorderLine(bottomRight, topRight);
+      this.addBorderLine(topRight, topLeft);
+      this.addBorderLine(topLeft, bottomLeft);
+    }
+  }
+
+  private static final LobbinLoboFieldMap fieldMap = new LobbinLoboFieldMap();
+
+  public LobbinLoco() {
+    super(fieldMap);
+  }
+
+  /**
+   * Places game pieces on the field according to the current game configuration. This method is
+   * called by the SimulatedArena class when the game starts. The method is responsible for placing
+   * the game pieces in the correct positions on the simulated field.
+   */
+  @Override
+  public void placeGamePiecesOnField() {
+    // no pieces on the field to start
+  }
+}


### PR DESCRIPTION
Introduces a unit-aware Pose2dJson class and adds a startingPose field to YAGSLDrivetrainJson, allowing configuration of the robot's initial pose. Updates VisionPropertiesJson to support a simulatedField property for dynamic simulation arena selection. Refactors YAGSLSwerveDrivetrain to accept an initial pose and adds the LobbinLoco simulated arena implementation. Updates related JSON config files to utilize these new features.