### PR TITLE
Refactor camera target handling and add distance API

### DIFF
--- a/src/main/deploy/basic_robot/cameras/shooter.json
+++ b/src/main/deploy/basic_robot/cameras/shooter.json
@@ -3,14 +3,18 @@
   "use": "target",
   "type": "photonvision",
   "column": 0,
-  "x": -0.25,
+  "x": 0.25,
   "y": 0,
   "z": 0.25,
   "roll": 0,
-  "pitch": 20,
-  "yaw": 180,
+  "pitch": 10,
+  "yaw": 0,
   "targetFiducialIds": [
-    4,
-    11
+    17,
+    18,
+    19,
+    20,
+    21,
+    22
   ]
 }

--- a/src/main/java/frc/robot/example/ExampleRobot.java
+++ b/src/main/java/frc/robot/example/ExampleRobot.java
@@ -4,6 +4,10 @@
 
 package frc.robot.example;
 
+import static edu.wpi.first.units.Units.RPM;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import org.frc5010.common.arch.GenericRobot;
 import org.frc5010.common.arch.StateMachine;
 import org.frc5010.common.arch.StateMachine.State;
@@ -12,10 +16,6 @@ import org.frc5010.common.constants.SwerveConstants;
 import org.frc5010.common.drive.GenericDrivetrain;
 import org.frc5010.common.motors.function.PercentControlMotor;
 import org.frc5010.common.sensors.Controller;
-
-import static edu.wpi.first.units.Units.RPM;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
 
 /** This is an example robot class. */
 public class ExampleRobot extends GenericRobot {
@@ -38,7 +38,6 @@ public class ExampleRobot extends GenericRobot {
     driver.createBButton().onTrue(exampleSubsystem.launchBall());
     driver.createXButton().whileTrue(exampleSubsystem.setDutyCycle(0.5));
     driver.createYButton().onTrue(exampleSubsystem.sysIdShooter());
-
 
     State idle = stateMachine.addState("idle", Commands.idle());
     stateMachine.setInitialState(idle);

--- a/src/main/java/frc/robot/example/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/example/ExampleSubsystem.java
@@ -1,8 +1,23 @@
 package frc.robot.example;
 
+import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+
+import com.revrobotics.spark.SparkMax;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
-
 import org.frc5010.common.arch.GenericSubsystem;
 import org.frc5010.common.constants.GenericPID;
 import org.frc5010.common.constants.MotorFeedFwdConstants;
@@ -23,23 +38,6 @@ import org.ironmaple.simulation.gamepieces.GamePieceProjectile;
 import org.ironmaple.simulation.seasonspecific.crescendo2024.NoteOnFly;
 import org.ironmaple.simulation.seasonspecific.reefscape2025.ReefscapeAlgaeOnFly;
 import org.littletonrobotics.junction.Logger;
-
-import com.revrobotics.spark.SparkMax;
-
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.math.util.Units;
-import static edu.wpi.first.units.Units.Degrees;
-import static edu.wpi.first.units.Units.Inches;
-import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecond;
-import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.wpilibj.RobotBase;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 import yams.mechanisms.velocity.Shooter;
 
 public class ExampleSubsystem extends GenericSubsystem {

--- a/src/main/java/org/frc5010/common/arch/GenericSubsystem.java
+++ b/src/main/java/org/frc5010/common/arch/GenericSubsystem.java
@@ -34,18 +34,18 @@ public class GenericSubsystem extends SubsystemBase
       new Alert(logPrefix + " Logging Mode is not COMPETITION!", AlertType.kWarning);
 
   /** Creates a new LoggedSubsystem. */
-  public GenericSubsystem(LoggedMechanism2d mechanismSimulation) {
+  protected GenericSubsystem(LoggedMechanism2d mechanismSimulation) {
     this.mechanismSimulation = mechanismSimulation;
     DashBoard = new DisplayValuesHelper(logPrefix, "values");
     WpiNetworkTableValuesHelper.register(this);
   }
 
-  public GenericSubsystem() {
+  protected GenericSubsystem() {
     DashBoard = new DisplayValuesHelper(logPrefix, "values");
     WpiNetworkTableValuesHelper.register(this);
   }
 
-  public GenericSubsystem(String configFile) {
+  protected GenericSubsystem(String configFile) {
     DashBoard = new DisplayValuesHelper(logPrefix, "values");
     try {
       GenericRobot.subsystemParser.parseSubsystem(this, configFile);

--- a/src/main/java/org/frc5010/common/sensors/camera/GenericCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/GenericCamera.java
@@ -63,6 +63,7 @@ public abstract class GenericCamera implements PoseProvider {
    *
    * @throws NullPointerException if any of the updaters are null
    */
+  @Override
   public void update() {
     updateCameraInfo();
     for (Runnable updater : updaters) {
@@ -145,4 +146,19 @@ public abstract class GenericCamera implements PoseProvider {
    * @return the area of the target
    */
   public abstract double getTargetArea();
+
+  /**
+   * A method to get the distance to the target.
+   *
+   * @return the distance to the target, or Double.MAX_VALUE if no valid target
+   */
+  public double getDistanceToTarget(double targetHeight) {
+    Transform3d camera2Robot = getRobotToCamera();
+    return hasValidTarget()
+        ? (targetHeight - camera2Robot.getTranslation().getZ())
+                / (Math.tan(Math.toRadians(getTargetPitch()) + camera2Robot.getRotation().getY())
+                    * Math.cos(Math.toRadians(getTargetYaw())))
+            + camera2Robot.getTranslation().getNorm()
+        : -1;
+  }
 }

--- a/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionPoseCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionPoseCamera.java
@@ -95,31 +95,31 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera {
     super.updateCameraInfo();
     Set<Short> tagIds = new HashSet<>();
 
-    for (PhotonPipelineResult camResult : camResults) {
-      Optional<EstimatedRobotPose> estimate = poseEstimator.update(camResult);
+    for (PhotonPipelineResult iCamResult : camResults) {
+      Optional<EstimatedRobotPose> estimate = poseEstimator.update(iCamResult);
       if (estimate.isPresent()) {
         EstimatedRobotPose estimatedRobotPose = estimate.get();
         Pose3d robotPose = estimatedRobotPose.estimatedPose;
 
         double totalTagDistance = 0.0;
-        for (var target : camResult.targets) {
-          totalTagDistance += target.bestCameraToTarget.getTranslation().getNorm();
+        for (var iTarget : iCamResult.targets) {
+          totalTagDistance += iTarget.bestCameraToTarget.getTranslation().getNorm();
         }
         // Compute the average tag distance
         int tagCount = estimatedRobotPose.targetsUsed.size();
         double averageDistance = 0.0;
-        if (camResult.targets.size() > 0) {
-          averageDistance = totalTagDistance / camResult.targets.size();
+        if (!iCamResult.targets.isEmpty()) {
+          averageDistance = totalTagDistance / iCamResult.targets.size();
         }
 
         // Add tag IDs
-        camResult.multitagResult.map(it -> tagIds.addAll(it.fiducialIDsUsed));
+        iCamResult.multitagResult.map(it -> tagIds.addAll(it.fiducialIDsUsed));
 
         SmartDashboard.putNumber(
             "Camera/" + name() + "/Total Distance To Tag " + name, totalTagDistance);
         SmartDashboard.putNumber(
             "Camera/" + name() + "/Photon Ambiguity " + name,
-            camResult.getBestTarget().poseAmbiguity);
+            iCamResult.getBestTarget().poseAmbiguity);
         SmartDashboard.putNumberArray(
             "Camera/" + name() + "/Photon Camera " + name + " POSE",
             new double[] {
@@ -130,10 +130,10 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera {
 
         observations.add(
             new PoseObservation(
-                camResult.getTimestampSeconds(), // Timestamp
+                iCamResult.getTimestampSeconds(), // Timestamp
                 // 3D pose estimate
                 robotPose,
-                camResult.getBestTarget().poseAmbiguity,
+                iCamResult.getBestTarget().poseAmbiguity,
                 tagCount,
                 averageDistance,
                 PoseObservationType.PHOTONVISION,

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedFiducialTargetCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedFiducialTargetCamera.java
@@ -4,18 +4,22 @@
 
 package org.frc5010.common.sensors.camera;
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Transform3d;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
 
 /** A simulated camera using the PhotonVision library. */
 public class SimulatedFiducialTargetCamera extends SimulatedCamera {
   /** The current list of fiducial IDs */
-  protected List<Integer> fiducialIds = new ArrayList<>();
+  protected List<Integer> targetFiducialIds = new ArrayList<>();
 
   /**
    * Constructor
@@ -43,7 +47,7 @@ public class SimulatedFiducialTargetCamera extends SimulatedCamera {
       int height,
       double fov) {
     super(name, colIndex, fieldLayout, strategy, cameraToRobot, poseSupplier, width, height, fov);
-    this.fiducialIds = fiducialIds;
+    targetFiducialIds = fiducialIds;
     visionLayout.addDouble("Target ID", () -> target.map(it -> it.getFiducialId()).orElse(-1));
   }
 
@@ -54,13 +58,77 @@ public class SimulatedFiducialTargetCamera extends SimulatedCamera {
     if (camResult.hasTargets()) {
       target =
           camResult.getTargets().stream()
-              .filter(it -> fiducialIds.contains(it.getFiducialId()))
+              .filter(it -> targetFiducialIds.contains(it.getFiducialId()))
               .findFirst();
+
+      input.hasTarget = target.isPresent();
+      input.latestTargetRotation =
+          target
+              .map(it -> new TargetRotation(new Rotation3d(0, it.getPitch(), it.getYaw())))
+              .orElse(new TargetRotation(new Rotation3d()));
+      input.latestTargetPose =
+          target
+              .map(
+                  it -> {
+                    Transform3d targetTrans = robotToCamera.plus(it.getBestCameraToTarget());
+                    return new Pose3d(targetTrans.getTranslation(), targetTrans.getRotation());
+                  })
+              .orElse(new Pose3d());
     }
   }
 
   @Override
   public boolean hasValidTarget() {
     return target.isPresent();
+  }
+
+  /**
+   * Gets the current list of fiducial IDs for this camera.
+   *
+   * @return the current list of fiducial IDs
+   */
+  public List<Integer> getFiducialIds() {
+    return targetFiducialIds;
+  }
+
+  /**
+   * Sets the list of fiducial IDs for this camera. The camera will only consider targets with IDs
+   * in this list when locating targets. This does not change the list spefified at construction
+   * time to the pose camera so that the camera can be both a pose and target camera.
+   *
+   * @param fiducialIds the list of fiducial IDs to consider
+   */
+  public void setFiducialIds(List<Integer> fiducialIds) {
+    targetFiducialIds = fiducialIds;
+  }
+
+  /**
+   * Updates the target information for this camera with the information from the given fiducial ID.
+   * This can be used to update the camera's target information when the camera is not able to
+   * locate a target.
+   *
+   * @param fiducialId the fiducial ID to update the target information from
+   */
+  public void updateTargetInfoToFiducial(int fiducialId) {
+    Pose3d fiducialPose = fieldLayout.getTagPose(fiducialId).orElse(new Pose3d());
+    input.latestTargetPose = fiducialPose;
+    input.latestTargetRotation =
+        new TargetRotation(
+            new Rotation3d(
+                0, fiducialPose.getRotation().getY(), fiducialPose.getRotation().getZ()));
+  }
+
+  /**
+   * Gets the distance from the current robot position to the current target position.
+   *
+   * @param targetHeight the height of the target
+   * @return the distance from the robot to the target
+   */
+  @Override
+  public double getDistanceToTarget(double targetHeight) {
+    return poseSupplier
+        .get()
+        .getTranslation()
+        .getDistance(input.latestTargetPose.getTranslation().toTranslation2d());
   }
 }

--- a/src/main/java/org/frc5010/common/subsystems/CameraSystem.java
+++ b/src/main/java/org/frc5010/common/subsystems/CameraSystem.java
@@ -4,9 +4,8 @@
 
 package org.frc5010.common.subsystems;
 
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.List;
+
 import org.frc5010.common.arch.GenericSubsystem;
 import org.frc5010.common.constants.Constants;
 import org.frc5010.common.sensors.camera.GenericCamera;
@@ -14,6 +13,9 @@ import org.frc5010.common.sensors.camera.SimulatedCamera;
 import org.ironmaple.simulation.SimulatedArena;
 import org.photonvision.estimation.TargetModel;
 import org.photonvision.simulation.VisionTargetSim;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 /**
  * This class is an abstract class that needs to be implemented by any subclass of CameraSystem. It

--- a/src/main/java/org/frc5010/common/subsystems/VisibleTargetSystem.java
+++ b/src/main/java/org/frc5010/common/subsystems/VisibleTargetSystem.java
@@ -4,7 +4,7 @@
 
 package org.frc5010.common.subsystems;
 
-import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Pose2d;
 import org.frc5010.common.sensors.camera.GenericCamera;
 
 public class VisibleTargetSystem extends CameraSystem {
@@ -14,12 +14,15 @@ public class VisibleTargetSystem extends CameraSystem {
   protected double targetYaw = 0;
   protected String TARGET_PITCH = "targetPitch";
   protected String TARGET_YAW = "targetYaw";
+  protected String TARGET_DISTANCE = "targetDistance";
+  protected Pose2d targetPose = new Pose2d();
 
   public VisibleTargetSystem(GenericCamera camera, double targetHeight) {
     super(camera);
     this.targetHeight = targetHeight;
     values.declare(TARGET_PITCH, 0.0);
     values.declare(TARGET_YAW, 0.0);
+    values.declare(TARGET_DISTANCE, 0.0);
 
     camera.registerUpdater(
         () -> {
@@ -45,13 +48,7 @@ public class VisibleTargetSystem extends CameraSystem {
    */
   @Override
   public double getDistanceToTarget() {
-    Transform3d camera2Robot = camera.getRobotToCamera();
-    return hasTargets
-        ? (targetHeight - camera2Robot.getTranslation().getZ())
-                / (Math.tan(Math.toRadians(targetPitch) + camera2Robot.getRotation().getY())
-                    * Math.cos(Math.toRadians(targetYaw)))
-            + camera2Robot.getTranslation().getNorm()
-        : -1;
+    return camera.getDistanceToTarget(targetHeight);
   }
 
   /**
@@ -80,5 +77,11 @@ public class VisibleTargetSystem extends CameraSystem {
    */
   public double getTargetPitch() {
     return targetPitch;
+  }
+
+  @Override
+  public void periodic() {
+    super.periodic();
+    values.set(TARGET_DISTANCE, getDistanceToTarget());
   }
 }

--- a/vendordeps/yams.json
+++ b/vendordeps/yams.json
@@ -1,18 +1,18 @@
 {
   "fileName": "yams.json",
   "name": "Yet Another Mechanism System",
-  "version": "2025.9.8",
+  "version": "2025.10.23.1",
   "frcYear": "2025",
   "uuid": "a1051e86-a979-4880-a28b-a0d5362d1d96",
   "mavenUrls": [
     "https://yet-another-software-suite.github.io/YAMS/releases/"
   ],
-  "jsonUrl": "https://yet-another-software-suite.github.io/YAMS/YAMS.json",
+  "jsonUrl": "https://yet-another-software-suite.github.io/YAMS/yams.json",
   "javaDependencies": [
     {
       "groupId": "yams",
       "artifactId": "YAMS-java",
-      "version": "2025.9.8"
+      "version": "2025.10.23.1"
     }
   ],
   "cppDependencies": [],


### PR DESCRIPTION
Refactored camera classes to use 'targetFiducialIds' instead of 'fiducialIds', added getter/setter methods for target IDs, and implemented a unified getDistanceToTarget API for both real and simulated cameras. Updated shooter camera config and vendordep version, and improved VisibleTargetSystem to expose target distance as a value. Also cleaned up imports and minor code organization in several files.