### PR TITLE
Remove stale Javadoc @param entries

### DIFF
--- a/src/main/java/org/frc5010/common/commands/AkitDriveCommands.java
+++ b/src/main/java/org/frc5010/common/commands/AkitDriveCommands.java
@@ -191,7 +191,6 @@ public class AkitDriveCommands {
    * <p>This command should only be used in voltage control mode.
    *
    * @param subsystem the swerve drivetrain subsystem to characterize
-   * @param drive the swerve drive implementation
    * @param characterizer consumer that accepts voltage values to apply to drive motors
    * @param velocitySupplier supplier that returns the current velocity for measurement
    * @return a command that performs feedforward characterization and logs results

--- a/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionPoseCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionPoseCamera.java
@@ -43,7 +43,6 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera implements Fiduci
    * @param name - the name of the camera
    * @param colIndex - the column index for the dashboard
    * @param fieldLayout - the field layout
-   * @param strategy - the pose strategy
    * @param cameraToRobot - the camera-to-robot transform
    * @param poseSupplier - the pose supplier
    */

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedCamera.java
@@ -37,7 +37,6 @@ public class SimulatedCamera extends PhotonVisionPoseCamera {
    * @param name - the name of the camera
    * @param colIndex - the column index for the dashboard
    * @param fieldLayout - the field layout
-   * @param strategy - the pose strategy
    * @param cameraToRobot - the camera-to-robot transform
    * @param poseSupplier - the pose supplier
    * @param width - the camera width

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedFiducialTargetCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedFiducialTargetCamera.java
@@ -24,7 +24,6 @@ public class SimulatedFiducialTargetCamera extends SimulatedCamera {
    * @param name - the name of the camera
    * @param colIndex - the column index for the dashboard
    * @param fieldLayout - the field layout
-   * @param strategy - the pose strategy
    * @param cameraToRobot - the camera-to-robot transform
    * @param poseSupplier - the pose supplier
    * @param fiducialIds - the list of fiducial IDs

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedVisualTargetCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedVisualTargetCamera.java
@@ -19,7 +19,6 @@ public class SimulatedVisualTargetCamera extends SimulatedCamera {
    * @param name - the name of the camera
    * @param colIndex - the column index for the dashboard
    * @param fieldLayout - the field layout
-   * @param strategy - the pose strategy
    * @param cameraToRobot - the camera-to-robot transform
    * @param poseSupplier - the pose supplier
    * @param width - the camera width


### PR DESCRIPTION
Clean up Javadoc comments to match current method signatures. Removed the obsolete 'drive' @param in AkitDriveCommands and the 'strategy' @param in PhotonVisionPoseCamera, SimulatedCamera, SimulatedFiducialTargetCamera, and SimulatedVisualTargetCamera. Documentation-only change to keep comments in sync with code; no behavioral changes.